### PR TITLE
Update "Edit" link to point to correct admin page

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,7 +13,7 @@
 # When viewing the details page for a location, there is an 'Edit' link
 # at the bottom of the page that takes you to the corresponding location
 # in the admin interface. Below, specify the URL for your Admin site.
-admin_site: https://ohana-api-demo.herokuapp.com/admin
+admin_site: https://hackforla-ohana-api.herokuapp.com/admin
 
 ##########################
 #
@@ -278,7 +278,7 @@ phone_extension_delimiter: x
 #
 ###########################################
 test:
-  admin_site: http://ohana-api-demo.herokuapp.com/admin
+  admin_site: https://hackforla-ohana-api.herokuapp.com/admin
 
   feedback_email:
     to:

--- a/spec/features/details/location_details_spec.rb
+++ b/spec/features/details/location_details_spec.rb
@@ -233,9 +233,8 @@ feature 'location details' do
     end
 
     it 'points to the corresponding location in the admin site' do
-      admin_site = 'http://ohana-api-demo.herokuapp.com/admin'
       expect(page).
-        to have_link('Edit', href: "#{admin_site}/locations/example-location")
+        to have_link('Edit', href: "#{SETTINGS[:admin_site]}/locations/example-location")
     end
 
     it 'includes rel=nofollow' do


### PR DESCRIPTION
This PR updates the "Edit" link on location pages to point to https://hackforla-ohana-api.herokuapp.com/admin instead of the Ohana API demo site.

It incorporates changes that are being sent upstream separately in https://github.com/codeforamerica/ohana-web-search/pull/860, but I don't foresee any difficulties merging in upstream changes once the other PR is merged.